### PR TITLE
2 reduce unnecessary reruns and improve performance

### DIFF
--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -128,7 +128,8 @@ export class JobSifter {
 
     private handleMutations = (mutations: MutationRecord[]): void => {
         for (const mutation of mutations) {
-
+            // INSERTIONS (New jobs loaded via scroll or page change)
+            // Target: Container, process the new children
             if (mutation.type === 'childList') {
 
                 mutation.addedNodes.forEach(node => {
@@ -145,7 +146,8 @@ export class JobSifter {
                 });
 
             } 
-            
+            // UPDATES (Text changes, attribute changes)
+            // Target: Node that changed, process its parent card
             else {
 
                 const targetElement = this.normalizeToElement(mutation.target);
@@ -159,6 +161,9 @@ export class JobSifter {
         }
     }
 
+    /**
+     * Helper: Safely converts raw nodes (like text or comments) into Elements.
+     */
     private normalizeToElement(node: Node): Element | null {
         if (node.nodeType === Node.TEXT_NODE) return node.parentElement;
         if (node.nodeType === Node.ELEMENT_NODE) return node as Element;
@@ -184,7 +189,7 @@ export class JobSifter {
             if (text && text.length > 0) textNodes.push(text);
         }
 
-        // 3. Stop early if the card is not loaded enough to contain key nodes
+        // Stop early if the card is not loaded enough to contain key nodes
         if (textNodes.length < 4) return null;
 
         return {

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -52,7 +52,7 @@ export class JobSifter {
     }
 
     //Make async later when adding chrome storage
-    public async startSifting(): Promise<void> {
+    public startSifting(): void {
         this.injectStyles();
         this.scanJobCards();
         this.initializeObserver();

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -25,6 +25,7 @@ export class JobSifter {
     // and rules on cards that haven't changed since the last observer tick.
     private precheckCache = new Map<string, { rawText: string, shouldFilter: boolean }>();
 
+    //Limits cache memory growth for heavy use
     private readonly MAX_CACHE_SIZE = 50;
 
     private sifterRules = {
@@ -187,8 +188,14 @@ export class JobSifter {
         return false;
     }
 
+    /**
+     * Replaces old precheckCache job card entries with new ones.
+     * Strategy: Uses First-In-First-Out eviction.
+     * Why:
+     * 1. Users scroll through job listings linearly to view new opportunities.
+     * 2. Once seen, old job cards are unlikely to be revisited.
+     */
     private updateCache(jobId: string, cardData: { rawText: string, shouldFilter: boolean }): void {
-        console.log(this.precheckCache.size)
         if (this.precheckCache.size >= this.MAX_CACHE_SIZE) {
             const oldestCard = this.precheckCache.keys().next().value;
             if (!oldestCard) return;

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -21,6 +21,8 @@ export class JobSifter {
     // DOM inserts. A single scroll event could trigger dozens of mutations.
     private scanTimeout: number | null = null;
 
+    // PERFORMANCE: A high-speed cache to prevent running the TreeWalker 
+    // and rules on cards that haven't changed since the last observer tick.
     private precheckCache = new Map<string, { rawText: string, shouldFilter: boolean }>();
 
     private sifterRules = {
@@ -119,7 +121,7 @@ export class JobSifter {
         const jobData = this.extractCardData(card, jobId);
         if (!jobData) return;
 
-        // 3. Evaluate & Execute
+        // Outsource evaluation for readability
         const shouldFilter = this.evaluateRules(jobData);
 
         this.precheckCache.set(jobId, { rawText: currentRawText, shouldFilter });

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -200,7 +200,7 @@ export class JobSifter {
             childList: true, 
             subtree: true, 
             attributes: true,
-            attributeFilter: ['class', 'data-occludable-job-id']
+            attributeFilter: ['data-occludable-job-id']
         }); 
     }
 }

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -17,10 +17,6 @@ interface CompiledMatchGroup {
 export class JobSifter {
     private observer: MutationObserver | null = null;
 
-    // We debounce the observer because Single Page Applications often batch 
-    // DOM inserts. A single scroll event could trigger dozens of mutations.
-    private scanTimeout: number | null = null;
-
     // PERFORMANCE: A high-speed cache to prevent running the TreeWalker 
     // and rules on cards that haven't changed since the last observer tick.
     private precheckCache = new Map<string, { rawText: string, shouldFilter: boolean }>();
@@ -70,7 +66,6 @@ export class JobSifter {
         if (this.observer) { 
             this.observer.disconnect();
             this.observer = null;
-            if (this.scanTimeout) window.clearTimeout(this.scanTimeout);
             console.log("Goldpan: Job Sifter stopped.");
         }
     }

--- a/src/core/JobSifter.ts
+++ b/src/core/JobSifter.ts
@@ -129,6 +129,18 @@ export class JobSifter {
     private handleMutations = (mutations: MutationRecord[]): void => {
         for (const mutation of mutations) {
 
+            const target = mutation.target.nodeType === Node.TEXT_NODE 
+                ? mutation.target.parentElement 
+                : mutation.target as HTMLElement;
+
+            if (target) {
+                const parentCard = target.closest(SELECTORS.JOB_CARD) as HTMLElement;
+                if (parentCard) {
+                    this.processJobCard(parentCard);
+                    continue; 
+                }
+            }
+
             if (mutation.type === 'childList') {
                 mutation.addedNodes.forEach(node => {
                     if (node instanceof HTMLElement) {


### PR DESCRIPTION
## Description
This PR reduces script reruns, minimizes memory usage at runtime, and improves job card hiding efficiency for a more seamless user experience.

## Related Tickets
- Implements #2  

## Changes Made
- Removed unnecessary `async` status from `startSifting()`.
- Removed `scanTimeout` property due to performance improvements making debouncing unnecessary.
- New cache `precheckCache` (with limited entries) for quicker job card analysis and application of hiding logic.
- New `updateCache()` method for handling cache manipulation logic using FIFO prioritization; based on user behavior.
- `observer` no longer fires on DOM element class changes to stop reruns on `goldpan-hidden` CSS class toggle.
- Renamed `scanJobCards()` to `scanInitialJobCards()` to reflect its' role as the first pass of filtering only.
- New `handleMutations()` method for handling insertions of new job cards and updates to existing ones.
- New `normalizeToElement()` helper method for simpler mutation analysis in `handleMutations()`.
- Removed `triggerScan()`, moving logic to separate `scanInitialJobCards()` and `handleMutations()` methods.
- Improved documentation for changed code explaining takeaways and insights.

## Impact & Risks
- Minimized flickering associated with application sifting.
- Minimize browser lag associated with application resource usage.
- Slightly noisy browser still due to LinkedIn throwing errors when job cards are hidden.

## How to Test
1. Pull this branch: `git checkout feature/2-reduce-unnecessary-reruns-and-improve-performance`.
2. Run `npm install`.
3. Edit the `SIFTER_CONFIG` values in `src/config/constants.ts`.
4. Run `npx vite build` or `npm run build`.
5. Go to your browser's extensions tab and enable _Developer Mode_.
6. Select _Load_ _Unpacked_ (different based on browser).
7. Select the `dist` folder inside the Goldpan repository location.
8. Enable the Goldpan extension.
9. Log in to LinkedIn and navigate to the _Jobs_ tab.
10. Perform a regular (non-AI) job search.
11. Verify filtering behavior works as intended, with minimal flickering and less browser lag.